### PR TITLE
package.json: s/repo/repository/

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "license": "MIT",
-  "repo": {
+  "repository": {
     "type":"git",
     "url": "https://github.com/dominictarr/through.git"
   },


### PR DESCRIPTION
npm doesn't know what a "repo" is.
