### PR TITLE
Ensure that end will be queued if paused with data

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function through (write, end) {
   var stream = new Stream(), buffer = []
   stream.buffer = buffer
   stream.readable = stream.writable = true
-  stream.paused = false  
+  stream.paused = false
   stream.write = function (data) {
     write.call(this, data)
     return !stream.paused
@@ -43,7 +43,7 @@ function through (write, end) {
 
   //this will be registered as the first 'end' listener
   //must call destroy next tick, to make sure we're after any
-  //stream piped from here. 
+  //stream piped from here.
   //this is only a problem if end is not emitted synchronously.
   //a nicer way to do this is to make sure this is the last listener for 'end'
 
@@ -63,10 +63,10 @@ function through (write, end) {
   }
 
   stream.end = function (data) {
-    if(ended) return 
+    if(ended) return
     ended = true
     if(arguments.length) stream.write(data)
-    if(!buffer.length) _end()
+    _end() // will emit or queue
   }
 
   stream.destroy = function () {

--- a/test/buffering.js
+++ b/test/buffering.js
@@ -35,3 +35,37 @@ exports['buffering'] = function (t) {
   t.end()
 
 }
+
+exports['buffering has data in queue, when ends'] = function (t) {
+
+  /*
+   * If stream ends while paused with data in the queue,
+   * stream should still emit end after all data is written
+   * on resume.
+   */
+
+  var ts = through(function (data) {
+    this.queue(data)
+  }, function () {
+    this.queue(null)
+  })
+
+  var ended = false,  actual = []
+
+  ts.on('data', actual.push.bind(actual))
+  ts.on('end', function () {
+    ended = true
+  })
+
+  ts.pause()
+  ts.write(1)
+  ts.write(2)
+  ts.write(3)
+  ts.end()
+  t.deepEqual(actual, [], 'no data written yet, still paused')
+  t.ok(!ended, 'end not emitted yet, still paused')
+  ts.resume()
+  t.deepEqual(actual, [1, 2, 3], 'resumed, all data should be delivered')
+  t.ok(ended, 'end should be emitted once all data was delivered')
+  t.end();
+}


### PR DESCRIPTION
Fix defect where end is not emitted with a buffering stream
when it is paused and has data in the buffer when it ends.

The `end()` method was only invoking `_end()` if the buffer
was empty, however `_end()` calls the user provided end fn
which is where the `queue(null)` would be called.

So if the stream is paused and there is data in the buffer
when `end()` is called, `queue(null)` (from the user end fn)
never gets invoked.

Change code to always call `_end()` regardless of buffer
length since it will simply `queue(null)` assuming user provided
proper buffer end fn.
