### PR TITLE
Alias `queue()` to `push()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function through (write, end) {
     }
   }
 
-  stream.queue = function (data) {
+  stream.queue = stream.push = function (data) {
     buffer.push(data)
     drain()
     return stream


### PR DESCRIPTION
streams2 as a [`push()`][1] that does effectively the same as `queue()`. 

It might be nice to allow `push()` to work on `through` aswell, or if 
we have time we can get @izs to pave the `queue()` cow-path.

  [1]: https://github.com/joyent/node/blob/master/doc/api/stream.markdown#readablepushchunk
