### PR TITLE
Test on 0.10 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - "0.10"


### PR DESCRIPTION
Tests pass on 0.10.4 on my machine. Any reason not to include it for Travis?
