### PR TITLE
Consistency with return values

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function through (write, end, opts) {
     while(buffer.length && !stream.paused) {
       var data = buffer.shift()
       if(null === data)
-        return stream.emit('end')
+        stream.emit('end')
       else
         stream.emit('data', data)
     }

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function through (write, end, opts) {
   }
 
   stream.end = function (data) {
-    if(ended) return
+    if(ended) return stream
     ended = true
     if(arguments.length) stream.write(data)
     _end() // will emit or queue
@@ -76,7 +76,7 @@ function through (write, end, opts) {
   }
 
   stream.destroy = function () {
-    if(destroyed) return
+    if(destroyed) return stream
     destroyed = true
     ended = true
     buffer.length = 0
@@ -86,7 +86,7 @@ function through (write, end, opts) {
   }
 
   stream.pause = function () {
-    if(stream.paused) return
+    if(stream.paused) return stream
     stream.paused = true
     return stream
   }


### PR DESCRIPTION
Hi,
Just started looking at this library and noticed chaining is inconsistently applied with the return values. For example if I do (this contrived example)

tr.pause().resume().pause();
this will work

if i do
tr.pause().pause().resume() 
this will not work
