### PR TITLE
Fix non-strict null check

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function through (write, end, opts) {
   stream.queue = stream.push = function (data) {
 //    console.error(ended)
     if(_ended) return stream
-    if(data == null) _ended = true
+    if(data === null) _ended = true
     buffer.push(data)
     drain()
     return stream

--- a/test/index.js
+++ b/test/index.js
@@ -115,3 +115,19 @@ test('pauses', function(assert) {
 
   write(expected, t)
 })
+
+test('does not soft-end on `undefined`', function(assert) {
+  var stream = through()
+    , count = 0
+
+  stream.on('data', function (data) {
+    count++
+  })
+
+  stream.write(undefined)
+  stream.write(undefined)
+
+  assert.equal(count, 2)
+
+  assert.end()
+})


### PR DESCRIPTION
Because of the `==` check vs. `===`, `undefined` was causing `_ended` to be flagged (and consequently no further `data` events to be emitted), without actually emitting any kind of `end` event, which lead to some surprises.