### PR TITLE
stream must be close properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ through.through = through
 
 function through (write, end, opts) {
   write = write || function (data) { this.queue(data) }
-  end = end || function () { this.queue(null) }
+  end = end || function () { }
 
   var ended = false, destroyed = false, buffer = [], _ended = false
   var stream = new Stream()
@@ -63,6 +63,7 @@ function through (write, end, opts) {
   function _end () {
     stream.writable = false
     end.call(stream)
+    stream.queue(null)
     if(!stream.readable && stream.autoDestroy)
       stream.destroy()
   }


### PR DESCRIPTION
Hi, the spec say nothing about `end` method must call `this.queue(null)` or `this.emit('end')`
without that, the stream will keep open,

I know this after play around with gulpfile
```js
const gulp = require('gulp');
const through = require('through');

gulp.task('lala', function() {
  return gulp.src([])
    .pipe(through(function() {}, function() {}));
})
```
the output of that task will be
```
[12:57:39] Using gulpfile ~/asdf/gulpfile.js
[12:57:39] Starting 'lala'...
```
there is no `Finished 'lala' after xx ms` line, that mean the stream was never closed properly

I think the default behavior should close the stream whenever the user explicitly call `this.queue(null)` or `this.emit('end')` or not at all. Because the spec said that `end` callback is optional, and never say the requirement when one use it

Another solution, just update the docs