### PR TITLE
Reorder package.json and add "files" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,28 +2,31 @@
   "name": "through",
   "version": "2.3.8",
   "description": "simplified stream construction",
-  "main": "index.js",
-  "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
-  },
-  "devDependencies": {
-    "stream-spec": "~0.3.5",
-    "tape": "~2.3.2",
-    "from": "~0.1.3"
-  },
   "keywords": [
+    "pipe",
     "stream",
     "streams",
-    "user-streams",
-    "pipe"
+    "user-streams"
   ],
-  "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
+  "homepage": "https://github.com/dominictarr/through",
   "license": "MIT",
+  "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
+  "files": [
+    "index.js"
+  ],
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/dominictarr/through.git"
   },
-  "homepage": "https://github.com/dominictarr/through",
+  "scripts": {
+    "test": "set -e; for t in test/*.js; do node $t; done"
+  },
+  "devDependencies": {
+    "from": "~0.1.3",
+    "stream-spec": "~0.3.5",
+    "tape": "~2.3.2"
+  },
   "testling": {
     "browsers": [
       "ie/8..latest",


### PR DESCRIPTION
Now npm will ignore all files except `index.js` and those stated in the [docs](https://docs.npmjs.com/files/package.json#files). This makes downloading this package a little faster for everyone.